### PR TITLE
Improve auth error handling

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -83,7 +83,11 @@ export async function POST(request: NextRequest) {
 
   } catch (error) {
     console.error('Chat processing error:', error);
-    
+
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     if (error instanceof z.ZodError) {
       return NextResponse.json(
         { error: 'Invalid input', details: error.errors },

--- a/src/app/api/compliance/search/route.ts
+++ b/src/app/api/compliance/search/route.ts
@@ -78,10 +78,14 @@ export async function GET(request: NextRequest) {
       total: data?.length || 0
     });
   } catch (error) {
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     if (error instanceof z.ZodError) {
       return NextResponse.json({ error: 'Invalid search parameters', details: error.errors }, { status: 400 });
     }
-    
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    return NextResponse.json({ error: 'Failed to search compliance' }, { status: 500 });
   }
 }

--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -58,8 +58,12 @@ export async function GET(request: NextRequest) {
         pages: Math.ceil((count || 0) / limit)
       }
     });
-  } catch {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    return NextResponse.json({ error: 'Failed to fetch leads' }, { status: 500 });
   }
 }
 
@@ -88,7 +92,11 @@ export async function POST(request: NextRequest) {
     if (error instanceof z.ZodError) {
       return NextResponse.json({ error: 'Invalid input', details: error.errors }, { status: 400 });
     }
-    
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    return NextResponse.json({ error: 'Failed to create lead' }, { status: 500 });
   }
 }

--- a/src/app/api/market/analysis/route.ts
+++ b/src/app/api/market/analysis/route.ts
@@ -35,7 +35,11 @@ export async function POST(request: NextRequest) {
     
   } catch (error) {
     console.error('Market analysis error:', error);
-    
+
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     if (error instanceof z.ZodError) {
       return NextResponse.json(
         { error: 'Invalid parameters', details: error.errors },
@@ -71,6 +75,10 @@ export async function GET(request: NextRequest) {
     
   } catch (error) {
     console.error('Market analysis error:', error);
+
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     return NextResponse.json(
       { error: 'Market analysis failed' },
       { status: 500 }

--- a/src/app/api/properties/[id]/route.ts
+++ b/src/app/api/properties/[id]/route.ts
@@ -30,6 +30,10 @@ export async function GET(
     
   } catch (error) {
     console.error('Property details error:', error);
+
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     return NextResponse.json(
       { error: 'Failed to get property details' },
       { status: 500 }

--- a/src/app/api/properties/search/route.ts
+++ b/src/app/api/properties/search/route.ts
@@ -66,7 +66,11 @@ export async function POST(request: NextRequest) {
     
   } catch (error) {
     console.error('Property search error:', error);
-    
+
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     if (error instanceof z.ZodError) {
       return NextResponse.json(
         { error: 'Invalid search parameters', details: error.errors },
@@ -119,6 +123,10 @@ export async function GET(request: NextRequest) {
     
   } catch (error) {
     console.error('Property search error:', error);
+
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     return NextResponse.json(
       { error: 'Property search failed' },
       { status: 500 }

--- a/src/app/api/saved-searches/route.ts
+++ b/src/app/api/saved-searches/route.ts
@@ -46,8 +46,11 @@ export async function GET(request: NextRequest) {
         pages: Math.ceil((count || 0) / limit)
       }
     });
-  } catch {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to fetch searches' }, { status: 500 });
   }
 }
 
@@ -76,7 +79,11 @@ export async function POST(request: NextRequest) {
     if (error instanceof z.ZodError) {
       return NextResponse.json({ error: 'Invalid input', details: error.errors }, { status: 400 });
     }
-    
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    return NextResponse.json({ error: 'Failed to create search' }, { status: 500 });
   }
 }

--- a/src/app/api/users/profile/route.ts
+++ b/src/app/api/users/profile/route.ts
@@ -27,8 +27,12 @@ export async function GET(request: NextRequest) {
     }
 
     return NextResponse.json(data);
-  } catch {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    return NextResponse.json({ error: 'Failed to fetch profile' }, { status: 500 });
   }
 }
 
@@ -58,7 +62,11 @@ export async function PUT(request: NextRequest) {
     if (error instanceof z.ZodError) {
       return NextResponse.json({ error: 'Invalid input', details: error.errors }, { status: 400 });
     }
-    
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    return NextResponse.json({ error: 'Failed to update profile' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- catch `requireAuth` errors and return 401 responses for unauthorized requests
- apply to all API routes that use `requireAuth`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing modules)*
- `npm test` *(fails: jest not found)*